### PR TITLE
Fixed README.md, CRIU.new, CRIU.target_pid= is undefined method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ libcriu (bundled with `criu` package in many case)
 ## Usage
 
 ```ruby
-CRIU.new(
-  images_dir: '/tmp/process_dump'
-)
+CRIU.images_dir = '/tmp/process_dump'
 CRIU.target_pid = 123
 CRIU.dump
 ```
@@ -41,9 +39,7 @@ CRIU.dump
 or
 
 ```ruby
-CRIU.new(
-  images_dir: '/tmp/process_dump'
-)
+CRIU.images_dir = '/tmp/process_dump'
 CRIU.restore
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ libcriu (bundled with `criu` package in many case)
 
 ```ruby
 CRIU.images_dir = '/tmp/process_dump'
-CRIU.target_pid = 123
+CRIU.pid = 123
 CRIU.dump
 ```
 


### PR DESCRIPTION
```console
% bundle exec ruby -e '
require "criu"
CRIU.new(
  images_dir: "/tmp/process_dump"
)'
Traceback (most recent call last):
-e:3:in `<main>': undefined method `new' for CRIU:Module (NoMethodError)
```

It seems `CRIU.new(images_dir: ...)` should be `CRIU.images_dir= ...`.
But `CRIU.images_dir=...` segv... (reported as #1).